### PR TITLE
feat: create dependabot CLs and build sample add-ons

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,18 @@ updates:
   - package-ecosystem: 'npm'
     directories:
       - '/addons-web-sdk/samples'
+    # Check for version updates every day.
     schedule:
       interval: 'daily'
-    # Ignore patches for everything except for @googleworkspace/meet-addons
+    # Group all changes across all samples into one PR.
+    groups:
+      versioning:
+        applies-to: version-updates
+      security:
+        applies-to: security-updates
+    # Ignore patches for enumerated dev dependencies.
     ignore:
       - dependency-name: '@types*'
-        update-types: ['version-update:semver-patch']
-      - dependency-name: 'next'
-        update-types: ['version-update:semver-patch']
-      - dependency-name: 'react*'
         update-types: ['version-update:semver-patch']
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-patch']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directories:
+      - '/addons-web-sdk/samples'
+    schedule:
+      interval: 'daily'
+    # Ignore patches for everything except for @googleworkspace/meet-addons
+    ignore:
+      - dependency-name: '@types*'
+        update-types: ['version-update:semver-patch']
+      - dependency-name: 'next'
+        update-types: ['version-update:semver-patch']
+      - dependency-name: 'react*'
+        update-types: ['version-update:semver-patch']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-patch']
+      - dependency-name: 'webpack*'
+        update-types: ['version-update:semver-patch']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,12 @@ updates:
     groups:
       versioning:
         applies-to: version-updates
+        patterns:
+          - '*'
       security:
         applies-to: security-updates
+        patterns:
+          - '*'
     # Ignore patches for enumerated dev dependencies.
     ignore:
       - dependency-name: '@types*'

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -1,0 +1,31 @@
+name: Build sample Add-ons
+
+on:
+  # Runs on all PRs, or when called from another workflow.
+  push:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: addons-web-sdk/samples/package-lock.json
+      - run: npm run build
+        working-directory: addons-web-sdk/samples
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: page
+          path: addons-web-sdk/samples/dist
+          if-no-files-found: error

--- a/.github/workflows/publish-sample-add-ons.yml
+++ b/.github/workflows/publish-sample-add-ons.yml
@@ -22,28 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: addons-web-sdk/samples/package-lock.json
-      - run: npm run build
-        working-directory: addons-web-sdk/samples
-      - name: Upload build
-        uses: actions/upload-artifact@v4
-        with:
-          name: page
-          path: addons-web-sdk/samples/dist
-          if-no-files-found: error
+    uses: ./.github/workflows/build-samples.yml
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
This proposes that once a day, dependabot check for new package updates (not just security updates) for the sample add-ons. In the PR that it creates to bump the version, it makes sure that the sample add-ons still build. Hopefully this serves three purposes:
- Keep our samples up-to-date with our latest @googleworkspace/meet-addons package version
- Ensure that all PRs build
- Flag any npm updates that break webpack usage reasonably early (within the same day). Not a full substitute for checks on our internal change lists, but at least it's something

Dependency updates should be bundled, separate PRs for version updates and security updates should contain all updated packages, except for patches to dev dependencies, which are ignored. It might make sense to use [the `allow` field](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) to only bump production dependencies, but I guess I'll see how noisy this bot is first.